### PR TITLE
Correct typo dash-3dcloud to dash-d3cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # dash-d3cloud
 
-dash-3dcloud is a Dash component library wrapping awesome [d3-cloud](https://www.jasondavies.com/wordcloud/) library and it's react wrapper [react-wordcloud](https://github.com/chrisrzhou/react-wordcloud)
+dash-d3cloud is a Dash component library wrapping awesome [d3-cloud](https://www.jasondavies.com/wordcloud/) library and it's react wrapper [react-wordcloud](https://github.com/chrisrzhou/react-wordcloud)
 
 
-This library can be installed via pip: `pip install dash-3dcloud`
+This library can be installed via pip: `pip install dash-d3cloud`
 
 The results it produces looks as follows:
 ![](https://raw.githubusercontent.com/trnkatomas/dash_d3cloud/master/img/usage.png)


### PR DESCRIPTION
The `pip install` command was referring to the wrong (non-existing) pypi package. This could be possibly dangerous if (until now) non-existing `dash-3dcloud` was hijacked.